### PR TITLE
fix: trust proxy headers behind Traefik and NGINX

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -27,6 +27,7 @@ app.use(cors({
 }));
 app.use(express.json());
 
+app.set("trust proxy", 2);
 // Rate limiting middleware
 // General API rate limit - 100 requests per 15 minutes per IP
 const apiLimiter = rateLimit({


### PR DESCRIPTION
## Summary

Configure Express to trust the Traefik and NGINX proxy chain.

## Changes

- Added `app.set("trust proxy", 2)`
- Fixes `ERR_ERL_UNEXPECTED_X_FORWARDED_FOR`
- Allows `express-rate-limit` to correctly identify client IPs behind the proxies

## Testing

- Confirmed the proxy validation error no longer appears
- Verified requests still reach the FairShare API
- Verified rate limiting continues to work

Closes #68 