### PR TITLE
ci: build error

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,6 +1,19 @@
+FROM node:20-alpine AS build
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+
+RUN npm run build
+
+
 FROM nginx:1.27-alpine
 
 COPY nginx.conf /etc/nginx/conf.d/default.conf
+
 COPY --from=build /app/dist /usr/share/nginx/html
 
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION

## Summary

Fix the FairShare client Docker build after moving Firebase configuration to runtime.

## Changes

- Restore the Node build stage
- Build the Vite app before copying it into NGINX
- Keep runtime Firebase configuration through the container entrypoint

Closes #86

