### PR TITLE
docs: prepare FairShare v0.1.0 preview release

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 FairShare is a full-stack roommate coordination app for managing chores, shared expenses, events, rooms, and chat in one place.
 
+> **Release status:** `v0.1.0` is an initial preview for one trusted household. Household isolation is not yet complete for chores, expenses, events, and roommate data. See the [v0.1.0 release notes](docs/releases/v0.1.0.md).
+
 ## Repository layout
 
 - `client/` — React + Vite frontend with Firebase Authentication
@@ -22,7 +24,7 @@ FairShare is a full-stack roommate coordination app for managing chores, shared 
 
 - Frontend: React 19, Vite, Axios, Firebase Web SDK
 - Backend: Node.js, Express 5, Mongoose, Firebase Admin SDK, Socket.IO
-- CI/CD: GitHub Actions (client lint/build, server install sanity, Firebase deploy on main/master)
+- CI/CD: GitHub Actions for validation, Firebase Hosting, and multi-architecture GHCR image builds
 
 ## Prerequisites
 
@@ -46,12 +48,16 @@ cd ../server && npm ci
 ### 2) Configure environment
 
 Create:
+
 - `client/.env`
 - `server/.env`
 
 See:
-- `docs/DEVELOPMENT.md` for full setup details
-- `docs/API.md` for API reference
+
+- [Development guide](docs/DEVELOPMENT.md) for full setup details
+- [API reference](docs/API.md) for endpoint details
+- [Architecture](docs/ARCHITECTURE.md) for application and deployment boundaries
+- [v0.1.0 release notes](docs/releases/v0.1.0.md) for included features and known limitations
 
 Note: local auth bypass (`ALLOW_DEV_AUTH=true`) is only honored when `NODE_ENV` is `development` or `test`.
 
@@ -68,6 +74,7 @@ npm run dev
 ```
 
 Default local URLs:
+
 - Frontend: `http://localhost:5173`
 - API: `http://localhost:5000/api`
 
@@ -89,14 +96,18 @@ Default local URLs:
 ## Validation
 
 Current CI validates:
+
 - Client lint (`npm run lint`)
 - Client build (`npm run build`)
-- Server dependency install sanity (`npm ci`)
+- Server dependency installation (`npm ci`) and entrypoint presence
 
 For local parity, run the same commands in each package directory.
 
 ## Deployment
 
-Deployment is handled by `.github/workflows/ci.yml`:
-- Runs on all pushes/PRs for validation jobs
-- Deploys to Firebase Hosting only on `main` or `master`
+GitHub Actions provides two delivery paths:
+
+- `.github/workflows/ci.yml` validates every push and pull request, and deploys the client to Firebase Hosting from `main` or `develop`.
+- `.github/workflows/build-images.yaml` builds AMD64 and ARM64 client/server images on pushes to `main`, then publishes commit-SHA tags to GHCR.
+
+K3s manifests and environment promotion are maintained in the separate [k3s-platform repository](https://github.com/Taku10/k3s-platform).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,65 @@
+# FairShare architecture
+
+This document describes the application as it exists in the `v0.1.0` preview.
+
+## System overview
+
+FairShare is a two-service web application:
+
+- **Client:** React 19 and Vite, served as static files by Nginx in the container image.
+- **API:** Node.js, Express 5, Mongoose, and Socket.IO.
+- **Authentication:** Firebase Authentication in the browser; Firebase Admin verifies ID tokens in the API and Socket.IO handshake.
+- **Data:** MongoDB stores roommates, rooms, chores, expenses, events, and chat messages.
+- **Images:** GitHub Actions builds multi-architecture client and server images and publishes commit-SHA tags to GHCR.
+
+The Kubernetes deployment configuration is maintained separately in the [k3s-platform repository](https://github.com/Taku10/k3s-platform).
+
+## Request flow
+
+1. A user signs in through Firebase Authentication.
+2. The client obtains a Firebase ID token.
+3. REST requests send the token in the `Authorization: Bearer <token>` header.
+4. The API verifies the token and resolves or creates the matching roommate record.
+5. Route handlers read or write MongoDB data.
+6. Chat uses an authenticated Socket.IO connection and joins a room only after membership is checked.
+
+## Main data entities
+
+| Entity | Purpose |
+| --- | --- |
+| `Roommate` | Application profile linked to a Firebase UID |
+| `Room` | Household-like group with a creator, members, and join code |
+| `Chore` | Assigned household task |
+| `Expense` | Shared cost and payment state |
+| `Event` | Calendar item or bill reminder |
+| `ChatMessage` | Message scoped to a room |
+
+## Delivery flow
+
+- Pull requests and branch pushes run the client lint/build and server installation checks.
+- Pushes to `main` build multi-architecture client and server images in GHCR.
+- The application repository also contains a Firebase Hosting deployment workflow.
+- K3s manifests and environment promotion are managed from `k3s-platform`.
+
+Container images are currently tagged with the first seven characters of the source commit SHA. A Git release tag identifies the source snapshot; it does not automatically retag the images.
+
+## Security and tenancy status
+
+Firebase authentication is enabled, and real-time chat verifies room membership. However, `v0.1.0` does **not** yet provide complete household isolation:
+
+- Chores, expenses, events, and roommate queries are not consistently scoped by room.
+- Some resource lookups do not consistently verify membership.
+- Some update paths accept broader input than a production multi-tenant API should.
+
+For that reason, this version is suitable as an initial preview or a single trusted household deployment. It should not be offered to unrelated households until every household-owned record includes a room identifier and every API operation verifies membership and role permissions.
+
+## Next architecture milestone
+
+The next milestone should introduce:
+
+1. A required `roomId` on all household-owned records.
+2. A reusable membership/role authorization middleware.
+3. Room-scoped query indexes such as `{ roomId: 1, createdAt: -1 }`.
+4. Explicit update allowlists instead of passing request bodies directly to database updates.
+5. Tests proving that a member of household A cannot read or change household B data.
+6. Invitation lifecycle, member removal, and owner/admin roles.

--- a/docs/releases/v0.1.0.md
+++ b/docs/releases/v0.1.0.md
@@ -1,0 +1,65 @@
+# FairShare v0.1.0 — Initial Preview
+
+**Status:** Prerelease  
+**Source:** `v0.1.0`
+
+This is the first versioned preview of FairShare, a full-stack application for coordinating life in a shared home.
+
+## Included
+
+- Email and password sign-in with Firebase Authentication
+- Room creation and joining with a room code
+- Chore assignment and completion tracking
+- Shared expense tracking and balance summaries
+- Roommate profiles
+- Calendar events and unpaid-bill reminders
+- Real-time room chat with Socket.IO
+- React/Vite client and Express/MongoDB API
+- Nginx client container and Node.js server container
+- GitHub Actions validation and multi-architecture GHCR image builds
+
+## Deployment notes
+
+- Client and server images are published with a seven-character commit SHA tag.
+- K3s deployment manifests are maintained in the separate [k3s-platform repository](https://github.com/Taku10/k3s-platform).
+- Operators should record the deployed client and server image SHAs alongside this release.
+- Review environment variables and secrets before deployment. Firebase web configuration is public application configuration; Firebase Admin credentials and MongoDB credentials must remain server-side secrets.
+
+## Known limitations
+
+- Multi-household isolation is incomplete. Chores, expenses, events, and roommate data are not yet consistently scoped and authorized by room.
+- Some API operations need stricter membership checks and field allowlists.
+- Automated test coverage is limited.
+- Household owner/admin roles and invitation management are not complete.
+- The API rate-limit settings should be reviewed against the actual reverse-proxy topology and expected traffic.
+
+Because of these limitations, this release should be treated as a preview for one trusted household, not as a production-ready multi-tenant service.
+
+## Validation before deployment
+
+Run the checks used by CI:
+
+```bash
+cd client
+npm ci
+npm run lint
+npm run build
+
+cd ../server
+npm ci
+test -f index.js
+```
+
+After deployment, verify:
+
+- The frontend loads and can sign in.
+- Authenticated API requests succeed.
+- Unauthenticated API requests return `401`.
+- The client can create or join a room.
+- Chat connects and exchanges messages.
+- The deployed image tags match the intended source commit.
+- MongoDB and application logs contain no unexpected authentication or connection errors.
+
+## Next release target
+
+The next milestone is full household tenancy: room-scoped data models and endpoints, reusable authorization middleware, cross-household isolation tests, and household role management.


### PR DESCRIPTION
## Summary

- add the FairShare architecture and delivery overview
- add versioned release notes for the first `v0.1.0` preview
- document the current household-isolation limitation
- link the new documentation from the README
- correct the README deployment description to match the current workflows

## Release decision

This is intentionally a prerelease. The current version is appropriate for one trusted household, but it is not yet safe as a multi-tenant service for unrelated households.

## Validation

Documentation-only change. Confirmed that the branch is based on the current `main` commit and contains only the three intended documentation files.